### PR TITLE
feat: add SteamAppPathProvider enhanced "open..."

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,10 @@
 [submodule "src/gui/thirdparty/vtflib"]
 	path = src/gui/thirdparty/vtflib
-	url = https://github.com/StrataSource/VTFLib
+	url = https://github.com/Trico-Everfire/VTFLib
+	branch = feat/floating_point_support
+[submodule "src/gui/thirdparty/sapp"]
+	path = src/gui/thirdparty/sapp
+	url = https://github.com/Trico-Everfire/SteamAppPathProvider.git
+[submodule "src/gui/thirdparty/speedykeyv"]
+	path = src/gui/thirdparty/speedykeyv
+	url = https://github.com/ozxybox/SpeedyKeyV.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "src/gui/thirdparty/vtflib"]
 	path = src/gui/thirdparty/vtflib
-	url = https://github.com/Trico-Everfire/VTFLib.git
-	branch = feat/floating_point_support
+	url = https://github.com/StrataSource/VTFLib.git
 [submodule "src/gui/thirdparty/sapp"]
 	path = src/gui/thirdparty/sapp
 	url = https://github.com/Trico-Everfire/SteamAppPathProvider.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/gui/thirdparty/vtflib"]
 	path = src/gui/thirdparty/vtflib
-	url = https://github.com/Trico-Everfire/VTFLib
+	url = https://github.com/Trico-Everfire/VTFLib.git
 	branch = feat/floating_point_support
 [submodule "src/gui/thirdparty/sapp"]
 	path = src/gui/thirdparty/sapp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ if(VPKTOOL_BUILD_GUI)
 
     set(VTFLIB_STATIC OFF CACHE BOOL "" FORCE)
     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/src/gui/thirdparty/vtflib")
+    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/src/gui/thirdparty/sapp")
+    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/src/gui/thirdparty/speedykeyv")
     set_target_properties(
             vtflib PROPERTIES
             # I don't know which one of these puts it next to the executable so let's do all of them!
@@ -85,7 +87,7 @@ if(VPKTOOL_BUILD_GUI)
             ${${PROJECT_NAME}_SOURCES})
 
     find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets)
-    target_link_libraries(${PROJECT_NAME} PRIVATE lib${PROJECT_NAME} vtflib Qt6::Core Qt6::Gui Qt6::Widgets)
+    target_link_libraries(${PROJECT_NAME} PRIVATE lib${PROJECT_NAME} vtflib SAPP keyvalues Qt6::Core Qt6::Gui Qt6::Widgets)
     target_include_directories(
             ${PROJECT_NAME} PRIVATE
             "${CMAKE_CURRENT_SOURCE_DIR}/include"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,15 +25,19 @@ if(VPKTOOL_BUILD_GUI)
     set(CMAKE_INSTALL_RPATH $ORIGIN)
 
     set(VTFLIB_STATIC OFF CACHE BOOL "" FORCE)
+
     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/src/gui/thirdparty/vtflib")
-    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/src/gui/thirdparty/sapp")
-    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/src/gui/thirdparty/speedykeyv")
+
     set_target_properties(
             vtflib PROPERTIES
             # I don't know which one of these puts it next to the executable so let's do all of them!
             ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
             LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
+    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/src/gui/thirdparty/speedykeyv")
+
+    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/src/gui/thirdparty/sapp")
 
     if(WIN32)
         if(DEFINED QT_BASEDIR)
@@ -87,7 +91,7 @@ if(VPKTOOL_BUILD_GUI)
             ${${PROJECT_NAME}_SOURCES})
 
     find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets)
-    target_link_libraries(${PROJECT_NAME} PRIVATE lib${PROJECT_NAME} vtflib SAPP keyvalues Qt6::Core Qt6::Gui Qt6::Widgets)
+    target_link_libraries(${PROJECT_NAME} PRIVATE lib${PROJECT_NAME} vtflib keyvalues SAPP Qt6::Core Qt6::Gui Qt6::Widgets)
     target_include_directories(
             ${PROJECT_NAME} PRIVATE
             "${CMAKE_CURRENT_SOURCE_DIR}/include"

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,6 @@
+# Contributors:
+
+## [Trico Everifre](https://github.com/Trico-Everfire)
+### Provided:
+[Steam App Path Provider](https://github.com/Trico-Everfire/SteamAppPathProvider)
+and/for "relative to..." path to VPK searching.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 MIT License
 
 Copyright (c) 2022 Brendan Lewis
-Copyright (c) 2023 Trico Everfire
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2022 Brendan Lewis
+Copyright (c) 2023 Trico Everfire
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/gui/Window.cpp
+++ b/src/gui/Window.cpp
@@ -34,6 +34,8 @@ Window::Window(QWidget* parent)
         this->open();
     });
 
+    auto* relativeToMenu = fileMenu->addMenu((tr("Open Relative To...")));
+
     CFileSystemSearchProvider provider;
     if(provider.Available()) {
         auto installedSteamAppCount = provider.GetNumInstalledApps();
@@ -47,7 +49,7 @@ Window::Window(QWidget* parent)
             auto* steamGameInfo = provider.GetAppInstallDirEX(steamAppIDs[i]);
             auto relativeDirectoryPath = QString(steamGameInfo->library) + "/common/" + steamGameInfo->installDir;
 
-            fileMenu->addAction(QIcon(steamGameInfo->icon), tr("Open Relative To... ") + QString(steamGameInfo->gameName), [=] {
+            relativeToMenu->addAction(QIcon(steamGameInfo->icon), QString(steamGameInfo->gameName), [=] {
                 this->openBasedOnPath(relativeDirectoryPath);
             });
 

--- a/src/gui/Window.cpp
+++ b/src/gui/Window.cpp
@@ -36,24 +36,25 @@ Window::Window(QWidget* parent)
 
     CFileSystemSearchProvider provider;
     if(provider.Available()) {
-        auto appCount = provider.GetNumInstalledApps();
-        auto appids = provider.GetInstalledAppsEX();
-        for(int i = 0; i < appCount; i++)
+        auto installedSteamAppCount = provider.GetNumInstalledApps();
+        auto* steamAppIDs = provider.GetInstalledAppsEX();
+
+        for(int i = 0; i < installedSteamAppCount; i++)
         {
-            if(!provider.BIsSourceGame(appids[i]))
+            if(!provider.BIsSourceGame(steamAppIDs[i]))
                 continue;
 
-            auto game = provider.GetAppInstallDirEX(appids[i]);
+            auto* steamGameInfo = provider.GetAppInstallDirEX(steamAppIDs[i]);
+            auto relativeDirectoryPath = QString(steamGameInfo->library) + "/common/" + steamGameInfo->installDir;
 
-            auto filePath = QString(game->library) + "/common/" + game->installDir;
-
-            fileMenu->addAction(QIcon(game->icon), tr("Open Relative To... ") + QString(game->gameName), [=] {
-                this->openBasedOnPath(filePath);
+            fileMenu->addAction(QIcon(steamGameInfo->icon), tr("Open Relative To... ") + QString(steamGameInfo->gameName), [=] {
+                this->openBasedOnPath(relativeDirectoryPath);
             });
-            delete game;
-        }
-        delete[] appids;
 
+            delete steamGameInfo;
+        }
+
+        delete[] steamAppIDs;
     }
 
     this->closeFileAction = fileMenu->addAction(this->style()->standardIcon(QStyle::SP_BrowserReload), tr("Close"), [=] {

--- a/src/gui/Window.h
+++ b/src/gui/Window.h
@@ -55,4 +55,6 @@ private:
     QAction* extractAllAction;
 
     void writeEntryToFile(const QString& path, const vpktool::VPKEntry& entry);
+
+    void openBasedOnPath(const QString &relativePath);
 };

--- a/src/gui/Window.h
+++ b/src/gui/Window.h
@@ -19,9 +19,9 @@ class Window : public QMainWindow {
 public:
     explicit Window(QWidget* parent = nullptr);
 
-    void open();
+    void open(const QString &relativePath);
 
-    bool open(const QString& path);
+    bool loadVPK(const QString& path);
 
     void closeFile();
 
@@ -55,6 +55,4 @@ private:
     QAction* extractAllAction;
 
     void writeEntryToFile(const QString& path, const vpktool::VPKEntry& entry);
-
-    void openBasedOnPath(const QString &relativePath);
 };


### PR DESCRIPTION
I added a nifty little QoL feature to allow you to open relative to a source game, given 99% of the use cases of using this tool is to extract files from Source Engine games, this will speed up navigation to those VPKs by a lot.

![image](https://github.com/craftablescience/VPKTool/assets/55441008/88049596-684d-47d7-a49e-338969d85bdf)
SAPP has been tested to be memory safe (tested with Valgrind) and provide fast lookups.
Both [SpeedyKeyV](https://github.com/ozxybox/SpeedyKeyV) (by Oxzybox) (required for SAPP) and [SteamAppPathProvider](https://github.com/Trico-Everfire/SteamAppPathProvider) (by me) are MIT licensed and can be compiled statically.